### PR TITLE
feat: create guards and decorators for auth

### DIFF
--- a/backend/src/module/auth/decorators/auth.decorator.ts
+++ b/backend/src/module/auth/decorators/auth.decorator.ts
@@ -1,0 +1,33 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { RoleProtected } from './role-protected.decorator';
+import { AuthGuard } from '@nestjs/passport';
+import { UserRoleGuard } from '../guards/user-role.guard';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { UserRole } from 'src/common/enums/userRole.enum';
+
+export function Auth(...roles: UserRole[]) {
+  return applyDecorators(
+    RoleProtected(...roles),
+    UseGuards(AuthGuard(), UserRoleGuard),
+    ApiBearerAuth(),
+    ApiUnauthorizedResponse({
+      description: 'El usuario no se autenticó',
+      example: {
+        message: 'Unauthorized',
+        statusCode: 401,
+      },
+    }),
+    ApiForbiddenResponse({
+      description: 'Usuario sin permisos para acceder al recurso',
+      example: {
+        message: 'Usuario sin permisos suficientes',
+        error: 'Forbidden',
+        statusCode: 403,
+      },
+    }),
+  );
+}

--- a/backend/src/module/auth/decorators/role-protected.decorator.ts
+++ b/backend/src/module/auth/decorators/role-protected.decorator.ts
@@ -1,0 +1,8 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from 'src/common/enums/userRole.enum';
+
+export const META_ROLES = 'roles';
+
+export const RoleProtected = (...args: UserRole[]) => {
+  return SetMetadata(META_ROLES, args);
+};

--- a/backend/src/module/auth/guards/owner-or-admin.guard.ts
+++ b/backend/src/module/auth/guards/owner-or-admin.guard.ts
@@ -1,0 +1,22 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { UserRole } from 'src/common/enums/userRole.enum';
+import { Users } from 'src/module/users/entities/users.entity';
+
+@Injectable()
+export class OwnerOrAdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const user = request.user as Users;
+
+    const idParam = request.params.id;
+
+    if (user?.role === UserRole.ADMIN || user.id == idParam) return true;
+    throw new ForbiddenException('Usuario sin permisos suficientes');
+  }
+}

--- a/backend/src/module/auth/stategies/jwt.strategy.ts
+++ b/backend/src/module/auth/stategies/jwt.strategy.ts
@@ -15,6 +15,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       secretOrKey: configService.get('JWT_SECRET') as string,
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
     });
   }
 

--- a/backend/src/module/users/users.controller.ts
+++ b/backend/src/module/users/users.controller.ts
@@ -1,13 +1,18 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { UsersService } from './users.service';
 import {
-  ApiParam,
-  ApiResponse,
   ApiOkResponse,
   ApiOperation,
   ApiNotFoundResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { QueryUsersDto } from './dtos/query-user.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { Auth } from '../auth/decorators/auth.decorator';
+import { UserRole } from 'src/common/enums/userRole.enum';
+import { OwnerOrAdminGuard } from '../auth/guards/owner-or-admin.guard';
 
 @Controller('users')
 export class UsersController {
@@ -83,11 +88,13 @@ export class UsersController {
       totalPages: 1,
     },
   })
+  @Auth(UserRole.ADMIN)
   @Get()
   getAllUsers(@Query() query: QueryUsersDto) {
     return this.usersService.findAll(query);
   }
 
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Obtener un usuario por su ID',
     description: 'Retorna los datos del usuario con el ID indicado',
@@ -122,6 +129,21 @@ export class UsersController {
       },
     },
   })
+  @ApiUnauthorizedResponse({
+    description: 'El usuario no se autenticó',
+    example: {
+      message: 'Unauthorized',
+      statusCode: 401,
+    },
+  })
+  @ApiForbiddenResponse({
+    description: 'Usuario sin permisos para acceder al recurso',
+    example: {
+      message: 'Usuario sin permisos suficientes',
+      error: 'Forbidden',
+      statusCode: 403,
+    },
+  })
   @ApiNotFoundResponse({
     description: 'No se ha encontrado un usuario con el ID indicado',
     example: {
@@ -131,6 +153,7 @@ export class UsersController {
       statusCode: 404,
     },
   })
+  @UseGuards(AuthGuard(), OwnerOrAdminGuard)
   @Get(':id')
   getUserById(@Param('id') id: string) {
     return this.usersService.findOneById(id);

--- a/backend/src/module/users/users.module.ts
+++ b/backend/src/module/users/users.module.ts
@@ -3,10 +3,11 @@ import { UsersService } from './users.service';
 import { Users } from './entities/users.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersController } from './users.controller';
+import { PassportModule } from '@nestjs/passport';
 
 @Module({
   providers: [UsersService],
-  imports: [TypeOrmModule.forFeature([Users])],
+  imports: [TypeOrmModule.forFeature([Users]), PassportModule.register({ defaultStrategy: 'jwt' })],
   controllers: [UsersController],
   exports: [UsersService],
 })


### PR DESCRIPTION
## Cambios realizados:
- Se crearon dos guards: user-role y owner-or-admin para proteger los endpoints por rol o por su id
- Se protegió la ruta /users para que solo pueda ser consumida por usuarios con el rol admin
- Se protegió la ruta /users/:id para que solo pueda ser consumida por usuarios admin o usuarios con el mismo ID