### PR TITLE
Fix/backend adopters

### DIFF
--- a/backend/src/module/adopters/adopters.module.ts
+++ b/backend/src/module/adopters/adopters.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { AdoptersService } from './adopters.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Adopters } from './entities/adopters.entity';
+import { Match } from '../matches/entities/match.entity';
 
 @Module({
   providers: [AdoptersService],
-  imports: [TypeOrmModule.forFeature([Adopters])],
+  imports: [TypeOrmModule.forFeature([Adopters, Match])],
   exports: [AdoptersService]
 })
 export class AdoptersModule {}

--- a/backend/src/module/adopters/adopters.service.ts
+++ b/backend/src/module/adopters/adopters.service.ts
@@ -1,13 +1,17 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { Adopters } from './entities/adopters.entity';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Match } from '../matches/entities/match.entity';
+import { MatchStatus } from '../../common/enums/match-status.enum';
 
 @Injectable()
 export class AdoptersService {
   constructor(
     @InjectRepository(Adopters)
     private readonly adoptersRepository: Repository<Adopters>,
+    @InjectRepository(Match)
+  private matchRepository: Repository<Match>,
   ) {}
 
   async create(createAdoptersDto: Adopters): Promise<Adopters> {
@@ -27,10 +31,33 @@ export class AdoptersService {
     id: string,
     updateAdopterDto: Partial<Adopters>,
   ): Promise<Adopters | null> {
+    const adopter = await this.adoptersRepository.findOne({ 
+      where: { id },
+      relations: ['user']
+    });
+    
+    if (!adopter) {
+      throw new NotFoundException(`Adopter con id ${id} no encontrado`);
+    }
+    
+    const activeMatches = await this.matchRepository.find({
+      where: [
+        { userId: adopter.user.id, status: MatchStatus.POR_REVISAR },
+        { userId: adopter.user.id, status: MatchStatus.EN_PROCESO }
+      ]
+    });
+    
+    if (activeMatches.length > 0) {
+      throw new BadRequestException(
+        'No se puede actualizar el perfil mientras existan solicitudes de adopción en estado "Por revisar" o "En proceso"'
+      );
+    }
+    
     const adopterUpdated = await this.adoptersRepository.update(
       id,
       updateAdopterDto,
     );
+    
     if (adopterUpdated.affected === 0) {
       throw new NotFoundException(`Adopter con id ${id} no encontrado`);
     }

--- a/backend/src/module/adopters/dtos/create-adopter.dto.ts
+++ b/backend/src/module/adopters/dtos/create-adopter.dto.ts
@@ -66,7 +66,8 @@ export class CreateAdopterDto {
     message: 'La dirección de residencia debe ser una cadena de texto',
   })
   @Matches(/^[a-zA-ZáéíóúÁÉÍÓÚüÜñÑ0-9\s,.#-]+$/, {
-    message: 'La dirección solo puede contener letras, números, espacios, comas, puntos, # y guiones',
+    message:
+      'La dirección solo puede contener letras, números, espacios, comas, puntos, # y guiones',
   })
   address: string;
 

--- a/backend/src/module/adopters/dtos/create-adopter.dto.ts
+++ b/backend/src/module/adopters/dtos/create-adopter.dto.ts
@@ -65,6 +65,9 @@ export class CreateAdopterDto {
   @IsString({
     message: 'La dirección de residencia debe ser una cadena de texto',
   })
+  @Matches(/^[a-zA-ZáéíóúÁÉÍÓÚüÜñÑ0-9\s,.#-]+$/, {
+    message: 'La dirección solo puede contener letras, números, espacios, comas, puntos, # y guiones',
+  })
   address: string;
 
   @ApiProperty({

--- a/backend/src/module/pets/dto/create-pet.dto.ts
+++ b/backend/src/module/pets/dto/create-pet.dto.ts
@@ -25,7 +25,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class CreatePetDto {
   @ApiProperty({ description: 'Nombre de la mascota', example: 'Firulais' })
   @IsString({ message: 'El nombre debe ser una cadena de texto' })
-  @Matches(/^[a-zA-ZáéíóúÁÉÍÓÚñÑ]+$/, { message: 'El nombre debe contener solo letras' })
+  @Matches(/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/, { message: 'El nombre debe contener solo letras' })
   name: string;
 
   @ApiProperty({

--- a/backend/src/module/pets/dto/create-pet.dto.ts
+++ b/backend/src/module/pets/dto/create-pet.dto.ts
@@ -25,7 +25,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class CreatePetDto {
   @ApiProperty({ description: 'Nombre de la mascota', example: 'Firulais' })
   @IsString({ message: 'El nombre debe ser una cadena de texto' })
-  @Matches(/^[a-zA-Z\s]+$/, { message: 'El nombre debe contener solo letras' })
+  @Matches(/^[a-zA-ZáéíóúÁÉÍÓÚñÑ]+$/, { message: 'El nombre debe contener solo letras' })
   name: string;
 
   @ApiProperty({


### PR DESCRIPTION
#PR Fixes
---
Se agregaron validaciones en Adopters:
- la dirección permite caracteres como letras, tildes, números, espacios, ","  , "-"  y "."
- En updateAdopters solo se permite realizar cambios sobre los atributos de adopters mientras que no tenga matchs activos con estado "Por revisar" o "En proceso".
- En pets se agregó validación para permitir tildes en el nombre.